### PR TITLE
Enhance "smtp" component filter

### DIFF
--- a/filter-50-smtp.conf
+++ b/filter-50-smtp.conf
@@ -8,8 +8,7 @@ filter {
       add_field => {
         "[postfix][eventtype]" => "smtp_to"
       }
-      # not yet grokked. postfix.detail could need more parsing
-      # add_tag => "grokked"
+      add_tag => "grokked"
     }
 
     if [server][domain] {

--- a/filter-50-smtp.conf
+++ b/filter-50-smtp.conf
@@ -1,27 +1,24 @@
 filter {
   if [postfix][component] == "smtp" {
-    if [message] =~ /^to=</ {
-      grok {
-        match => ["message","to=<%{DATA:[destination][user][email]}>(, orig_to=<%{DATA:[postfix][orig_to]}>)?, relay=%{HOSTNAME:[server][domain]}\[%{IP:[service][ip]}\]:%{NUMBER:[server][port]:int}, delay=%{NUMBER:[postfix][delay]:float}, delays=%{DATA:[postfix][delays]}, dsn=%{DATA:[postfix][dsn]}, status=%{WORD:[postfix][status]} \(%{GREEDYDATA:[postfix][detail]}\)"]
-        id => "postfix_smtp"
-        tag_on_failure => ["_grokparsefailure","postfix_smtp_failed"]
-        add_field => {
-          "[postfix][eventtype]" => "smtp_to"
-        }
-        add_tag => "grokked"
-      }
-    }
-    # the current implementation expects the log to have both ip and domain field set. If we have to change that
-    # we must change the following filter as well
-    mutate {
+
+    grok {
+      match => ["message","(to=<%{DATA:[destination][user][email]}>(, orig_to=<%{DATA:[postfix][orig_to]}>)?, relay=%{HOSTNAME:[server][domain]}\[%{IP:[service][ip]}\]:%{NUMBER:[server][port]:int}, delay=%{NUMBER:[postfix][delay]:float}, delays=%{DATA:[postfix][delays]}, dsn=%{DATA:[postfix][dsn]}, status=%{WORD:[postfix][status]} \()?%{GREEDYDATA:[postfix][detail]}(\))?"]
+      id => "postfix_smtp"
+      tag_on_failure => ["_grokparsefailure","postfix_smtp_failed"]
       add_field => {
-        "[server][address]" => "%{[server][domain]}"
-        "[ecs][version]" => "1.5.0"
+        "[postfix][eventtype]" => "smtp_to"
+      }
+      # not yet grokked. postfix.detail could need more parsing
+      # add_tag => "grokked"
+    }
+
+    if [server][domain] {
+      mutate {
+        add_field => {
+          "[server][address]" => "%{[server][domain]}"
+        }
       }
     }
+
   }
 }
-# TODO
-# Trusted TLS connection established to
-# host
-# open active


### PR DESCRIPTION
fixes #16

This filter now mainly consists of a big GREEDYDATA pattern that will match on all information postfix throws at us.

But if the message contains extra (structured) information it will parse that as well. This will help to work around the fact that sometimes only the detail information is the whole message and sometimes it's encapsulated in () with more information