### PR TITLE
Add geoip filter

### DIFF
--- a/filter-90-geoip.conf
+++ b/filter-90-geoip.conf
@@ -1,15 +1,15 @@
 filter {
 
-# we haven't found an event that countains source.ip and
+# we haven't found an event that countains server.ip and
 # client.ip at the same time. So to make filters and dashboards
 # easier we write both in the same field
 #
 # if there's a message that contains both, we need to change
 # this filter
 
-  if [source][ip] {
+  if [server][ip] {
     geoip {
-      source => "[source][ip]"
+      source => "[server][ip]"
     }
   }
 

--- a/filter-90-geoip.conf
+++ b/filter-90-geoip.conf
@@ -1,0 +1,21 @@
+filter {
+
+# we haven't found an event that countains source.ip and
+# client.ip at the same time. So to make filters and dashboards
+# easier we write both in the same field
+#
+# if there's a message that contains both, we need to change
+# this filter
+
+  if [source][ip] {
+    geoip {
+      source => "[source][ip]"
+    }
+  }
+
+  if [client][ip] {
+    geoip {
+      source => "[client][ip]"
+    }
+  }
+}


### PR DESCRIPTION
 We use the same target field for all geo information to make filters and dashboards easier to build. If we encounter an event that contains both `source.ip` and `client.ip` we need to change this filter.