### PR TITLE
Set target in GeoIP filter

### DIFF
--- a/filter-90-geoip.conf
+++ b/filter-90-geoip.conf
@@ -6,16 +6,22 @@ filter {
 #
 # if there's a message that contains both, we need to change
 # this filter
+#
+# To change, just remove the `target` option. See
+# https://www.elastic.co/guide/en/logstash/current/plugins-filters-geoip.html#plugins-filters-geoip-target
+# for more details
 
   if [server][ip] {
     geoip {
       source => "[server][ip]"
+      target => "geoip"
     }
   }
 
   if [client][ip] {
     geoip {
       source => "[client][ip]"
+      target => "geoip"
     }
   }
 }


### PR DESCRIPTION
See https://www.elastic.co/guide/en/logstash/current/plugins-filters-geoip.html#plugins-filters-geoip-target for more details. The default for `target` changed and we set it back to the old one in this case.